### PR TITLE
It compiles now

### DIFF
--- a/src/tolitius/checker/eastwood.clj
+++ b/src/tolitius/checker/eastwood.clj
@@ -13,7 +13,7 @@
       (let [sources# #{~@(tmp-dir-paths fileset)}
             _ (boot.util/dbug (str "eastwood is about to look at: -- " sources# " --"))
             {:keys [some-warnings] :as checks} (eastwood/eastwood {:source-paths sources#
-                                                                   :exclude-linters exclude-linters
+                                                                   :exclude-linters ~exclude-linters
                                                                    ;; :debug #{:ns}
                                                                    })]
         (if some-warnings


### PR DESCRIPTION
The surprising thing for you was that you defined the exclude-linters
symbol, but then you could not refer to it inside of the with-eval-in
block (Note that you can refer to it anywhere outside of with-eval-in
just fine).

The idea behind with-eval-in is that it takes *literal* code as an
argument, ships it to some other process, and then _that_ process evals
it. When I say literal code, I mean when you write "(+ 1 2)", you dont
ship the value "3" to the pod, you ship a list containing the symbol '+,
the number 1 and the number 2, and then _it_ executes the + function by
doing (eval '(+ 1 2))!

For a more topical example, when we ship the
"... {:exclude-linters exclude-linters} ..." bit over to the next pod,
that pod will eventually do:

(eval "... {:exclude-linters exclude-linters} ...")

It actually receives a map containing that :exclude-linters keyword,
mapped to the literal symbol 'exclude-linters. It then discovers that
the 'exclude-linters symbol is not defined anywhere when it attempts to
eval it.

When I change the code to "... {:exclude-linters ~exclude-linters} ...",
the other pod instead gets something like this:

(eval "... {:exclude-linters [:unused-ret-vals]} ...")

My use of the tilde (~) tells Clojure to "unquote" the symbol, which
means to literally embed its value in the generated code before it gets
shipped out. Put another way, it looks up the value of 'exclude-linters
in a context where that symbol is actually defined (inside the check
function), builds the code using its value instead of the literal
symbol, and _then_ ships it to the pod.  Because of this, the other pod
doesn't ever attempt to resolve the symbol 'exclude-linters.

Hope this makes sense!